### PR TITLE
fixed border values for getRentalByPricePerNight

### DIFF
--- a/src/main/java/com/AirBnb/TimberAndStone/repositories/RentalRepository.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/repositories/RentalRepository.java
@@ -3,16 +3,19 @@ package com.AirBnb.TimberAndStone.repositories;
 import com.AirBnb.TimberAndStone.models.Category;
 import com.AirBnb.TimberAndStone.models.Rental;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 
 public interface RentalRepository extends MongoRepository<Rental, String> {
     List<Rental> findByCategory(Category category);
 
-    // https://chatgpt.com/share/67b33e5b-0968-800b-bb00-ba09744d98fb
+    // https://chatgpt.com/share/67bf0c89-4cac-800b-9d3e-bcd5eeb0e944
     List<Rental> findByRatingAverageRatingGreaterThanEqualAndRatingNumberOfRatingsGreaterThanEqual(Double avgRating, Integer numberOfRatings);
 
-    List<Rental> findByPricePerNightBetween(Double minPrice, Double maxPrice);
+    // https://chatgpt.com/share/67bf07f3-8c18-800b-bcce-c51086343cfd
+    @Query("{'pricePerNight': { $gte: ?0, $lte: ?1 }}")
+    List<Rental> findByPricePerNightBetweenInclusive(Double minPrice, Double maxPrice);
 
     List<Rental> findByRatingAverageRating(Double averageRating);
 

--- a/src/main/java/com/AirBnb/TimberAndStone/services/RentalService.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/services/RentalService.java
@@ -91,7 +91,7 @@ public class RentalService {
     }
 
     public List<RentalFindByPricePerNightRangeResponse> getRentalsByPricePerNightRange(Double minPrice, Double maxPrice) {
-        List<Rental> rentals = rentalRepository.findByPricePerNightBetween(minPrice, maxPrice);
+        List<Rental> rentals = rentalRepository.findByPricePerNightBetweenInclusive(minPrice, maxPrice);
 
         return rentals.stream()
                 .map(this::convertToDTO)


### PR DESCRIPTION
PULL REQUEST STANDARD EX:

# Pull Request Template

## Notes & Questions For The Reviewer


## What has been changed?
Updated:
    @Query("{'pricePerNight': { $gte: ?0, $lte: ?1 }}")
    List<Rental> findByPricePerNightBetweenInclusive(Double minPrice, Double maxPrice);

So now i includes the border values when doing the search.


![image](https://github.com/user-attachments/assets/d126b263-d577-4295-8c2e-b9bc144cf7c4)





## Why did I make these changes?
We want to border values to be reflected in the search

## How can others test my code?
check out branch
start server
test every endpoint in postman
Test negativ scenarios, for example making error or trying to find resources that dont exist.

Checklist before sending in you PR
Check each box by adding an X to [ ] - [x]
[x] - I have tested my code and it works the way i want it to
[x] - My code follows our code standards (tex validation, names, etc)
[x] - I have commented komplicated parts of code (if needed)
[x] - I have uppdated dokumentation (if needed)

Remember that:
Be humble and open for feedback
Answer the comments quickly
Its okay to make mistakes
