### PR TITLE
132 rental   remove double validation

### DIFF
--- a/src/main/java/com/AirBnb/TimberAndStone/controllers/RentalReviewController.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/controllers/RentalReviewController.java
@@ -46,7 +46,9 @@ public class RentalReviewController {
     public ResponseEntity<List<RentalReviewsResponse>> getRentalReviewsByRentalId(@Valid @PathVariable String id) {
         List<RentalReviewsResponse> rentalReviews = rentalReviewService.getRentalReviewByRentalId(id);
         return ResponseEntity.ok(rentalReviews);
+
         }
+
         @GetMapping("rental/host/{id}")
         public ResponseEntity<List<RentalReviewsResponse>> getRentalReviewsByHostId(@Valid @PathVariable String id) {
          List<RentalReviewsResponse> rentalReviews = rentalReviewService.getRentalReviewByHostId(id);

--- a/src/main/java/com/AirBnb/TimberAndStone/models/Address.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/models/Address.java
@@ -65,51 +65,51 @@ public class Address {
         this.country = country;
     }
 
-    public @NotNull(message = "City can not be null") @NotEmpty(message = "City can not be empty") String getCity() {
+    public @NotEmpty(message = "City can not be empty") String getCity() {
         return city;
     }
 
-    public void setCity(@NotNull(message = "City can not be null") @NotEmpty(message = "City can not be empty") String city) {
+    public void setCity(@NotEmpty(message = "City can not be empty") String city) {
         this.city = city;
     }
 
-    public @NotNull(message = "Postal code can not be null") @NotEmpty(message = "Postal code can not be empty") String getPostalCode() {
+    public @NotEmpty(message = "Postal code can not be empty") String getPostalCode() {
         return postalCode;
     }
 
-    public void setPostalCode(@NotNull(message = "Postal code can not be null") @NotEmpty(message = "Postal code can not be empty") String postalCode) {
+    public void setPostalCode(@NotEmpty(message = "Postal code can not be empty") String postalCode) {
         this.postalCode = postalCode;
     }
 
-    public @NotNull(message = "Street name can not be null") @NotEmpty(message = "Street name can not be empty") String getStreetName() {
+    public @NotEmpty(message = "Street name can not be empty") String getStreetName() {
         return streetName;
     }
 
-    public void setStreetName(@NotNull(message = "Street name can not be null") @NotEmpty(message = "Street name can not be empty") String streetName) {
+    public void setStreetName(@NotEmpty(message = "Street name can not be empty") String streetName) {
         this.streetName = streetName;
     }
 
-    public @NotNull(message = "Street number can not be null") @NotEmpty(message = "Street number can not be empty") String getStreetNumber() {
+    public @NotEmpty(message = "Street number can not be empty") String getStreetNumber() {
         return streetNumber;
     }
 
-    public void setStreetNumber(@NotNull(message = "Street number can not be null") @NotEmpty(message = "Street number can not be empty") String streetNumber) {
+    public void setStreetNumber(@NotEmpty(message = "Street number can not be empty") String streetNumber) {
         this.streetNumber = streetNumber;
     }
 
-    public @NotNull(message = "Latitude can not be null") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double getLatitude() {
+    public @NotEmpty(message = "Latitude can not be empty") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double getLatitude() {
         return latitude;
     }
 
-    public void setLatitude(@NotNull(message = "Latitude can not be null") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double latitude) {
+    public void setLatitude(@NotEmpty(message = "Latitude can not be empty") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double latitude) {
         this.latitude = latitude;
     }
 
-    public @NotNull(message = "Longitude can not be null") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double getLongitude() {
+    public @NotEmpty(message = "Longitude can not be empty") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double getLongitude() {
         return longitude;
     }
 
-    public void setLongitude(@NotNull(message = "Longitude can not be null") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double longitude) {
+    public void setLongitude(@NotEmpty(message = "Longitude can not be empty") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double longitude) {
         this.longitude = longitude;
     }
 }

--- a/src/main/java/com/AirBnb/TimberAndStone/models/Address.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/models/Address.java
@@ -12,19 +12,19 @@ public class Address {
     @NotEmpty(message = "Country can not be empty")
     private String country;
 
-    @NotNull(message = "City can not be null")
+    //@NotNull(message = "City can not be null")
     @NotEmpty(message = "City can not be empty")
     private String city;
 
-    @NotNull(message = "Postal code can not be null")
+    //@NotNull(message = "Postal code can not be null")
     @NotEmpty(message = "Postal code can not be empty")
     private String postalCode;
 
-    @NotNull(message = "Street name can not be null")
+    //@NotNull(message = "Street name can not be null")
     @NotEmpty(message = "Street name can not be empty")
     private String streetName;
 
-    @NotNull(message = "Street number can not be null")
+    //@NotNull(message = "Street number can not be null")
     @NotEmpty(message = "Street number can not be empty")
     private String streetNumber;
 
@@ -97,19 +97,19 @@ public class Address {
         this.streetNumber = streetNumber;
     }
 
-    public @NotEmpty(message = "Latitude can not be empty") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double getLatitude() {
+    public @NotNull(message = "Latitude can not be empty") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double getLatitude() {
         return latitude;
     }
 
-    public void setLatitude(@NotEmpty(message = "Latitude can not be empty") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double latitude) {
+    public void setLatitude(@NotNull(message = "Latitude can not be empty") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double latitude) {
         this.latitude = latitude;
     }
 
-    public @NotEmpty(message = "Longitude can not be empty") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double getLongitude() {
+    public @NotNull(message = "Longitude can not be empty") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double getLongitude() {
         return longitude;
     }
 
-    public void setLongitude(@NotEmpty(message = "Longitude can not be empty") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double longitude) {
+    public void setLongitude(@NotNull(message = "Longitude can not be empty") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double longitude) {
         this.longitude = longitude;
     }
 }

--- a/src/main/java/com/AirBnb/TimberAndStone/models/Address.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/models/Address.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotNull;
 
 public class Address {
 
-    @NotNull(message = "Country can not be null")
+    //@NotNull(message = "Country can not be null")
     @NotEmpty(message = "Country can not be empty")
     private String country;
 
@@ -56,11 +56,12 @@ public class Address {
 
     //--------------------------------------------- Getter & Setters -------------------------------------------------------
 
-    public @NotNull(message = "Country can not be null") @NotEmpty(message = "Country can not be empty") String getCountry() {
+
+    public @NotEmpty(message = "Country can not be empty") String getCountry() {
         return country;
     }
 
-    public void setCountry(@NotNull(message = "Country can not be null") @NotEmpty(message = "Country can not be empty") String country) {
+    public void setCountry(@NotEmpty(message = "Country can not be empty") String country) {
         this.country = country;
     }
 

--- a/src/main/java/com/AirBnb/TimberAndStone/models/Address.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/models/Address.java
@@ -8,33 +8,33 @@ import jakarta.validation.constraints.NotNull;
 
 public class Address {
 
-    //@NotNull(message = "Country can not be null")
-    @NotEmpty(message = "Country can not be empty")
+
+    @NotEmpty(message = "Country can not be empty or null")
     private String country;
 
-    //@NotNull(message = "City can not be null")
-    @NotEmpty(message = "City can not be empty")
+
+    @NotEmpty(message = "City can not be empty or null")
     private String city;
 
-    //@NotNull(message = "Postal code can not be null")
-    @NotEmpty(message = "Postal code can not be empty")
+
+    @NotEmpty(message = "Postal code can not be empty or null")
     private String postalCode;
 
-    //@NotNull(message = "Street name can not be null")
-    @NotEmpty(message = "Street name can not be empty")
+
+    @NotEmpty(message = "Street name can not be empty or null")
     private String streetName;
 
-    //@NotNull(message = "Street number can not be null")
-    @NotEmpty(message = "Street number can not be empty")
+
+    @NotEmpty(message = "Street number can not be empty or null")
     private String streetNumber;
 
     //-- Latitude and longitude in decimal degrees format (ex. 41.40338, 2.17403)
-    @NotNull(message = "Latitude can not be null")
+    @NotNull(message = "Latitude can not be empty or null")
     @Min(value = -90L, message = "Latitude has to be between -90 & +90")
     @Max(value = 90L, message = "Latitude has to be between -90 & +90")
     private Double latitude;
 
-    @NotNull(message = "Longitude can not be null")
+    @NotNull(message = "Longitude can not be empty or null")
     @Min(value = -180L, message = "Latitude has to be between -180 & +180")
     @Max(value = 180L, message = "Latitude has to be between -180 & +180")
     private Double longitude;
@@ -57,59 +57,59 @@ public class Address {
     //--------------------------------------------- Getter & Setters -------------------------------------------------------
 
 
-    public @NotEmpty(message = "Country can not be empty") String getCountry() {
+    public @NotEmpty(message = "Country can not be empty or null") String getCountry() {
         return country;
     }
 
-    public void setCountry(@NotEmpty(message = "Country can not be empty") String country) {
+    public void setCountry(@NotEmpty(message = "Country can not be empty or null") String country) {
         this.country = country;
     }
 
-    public @NotEmpty(message = "City can not be empty") String getCity() {
+    public @NotEmpty(message = "City can not be empty or null") String getCity() {
         return city;
     }
 
-    public void setCity(@NotEmpty(message = "City can not be empty") String city) {
+    public void setCity(@NotEmpty(message = "City can not be empty or null") String city) {
         this.city = city;
     }
 
-    public @NotEmpty(message = "Postal code can not be empty") String getPostalCode() {
+    public @NotEmpty(message = "Postal code can not be empty or null") String getPostalCode() {
         return postalCode;
     }
 
-    public void setPostalCode(@NotEmpty(message = "Postal code can not be empty") String postalCode) {
+    public void setPostalCode(@NotEmpty(message = "Postal code can not be empty or null") String postalCode) {
         this.postalCode = postalCode;
     }
 
-    public @NotEmpty(message = "Street name can not be empty") String getStreetName() {
+    public @NotEmpty(message = "Street name can not be empty or null") String getStreetName() {
         return streetName;
     }
 
-    public void setStreetName(@NotEmpty(message = "Street name can not be empty") String streetName) {
+    public void setStreetName(@NotEmpty(message = "Street name can not be empty or null") String streetName) {
         this.streetName = streetName;
     }
 
-    public @NotEmpty(message = "Street number can not be empty") String getStreetNumber() {
+    public @NotEmpty(message = "Street number can not be empty or null") String getStreetNumber() {
         return streetNumber;
     }
 
-    public void setStreetNumber(@NotEmpty(message = "Street number can not be empty") String streetNumber) {
+    public void setStreetNumber(@NotEmpty(message = "Street number can not be empty or null") String streetNumber) {
         this.streetNumber = streetNumber;
     }
 
-    public @NotNull(message = "Latitude can not be empty") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double getLatitude() {
+    public @NotNull(message = "Latitude can not be empty or null") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double getLatitude() {
         return latitude;
     }
 
-    public void setLatitude(@NotNull(message = "Latitude can not be empty") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double latitude) {
+    public void setLatitude(@NotNull(message = "Latitude can not be empty or null") @Min(value = -90L, message = "Latitude has to be between -90 & +90") @Max(value = 90L, message = "Latitude has to be between -90 & +90") Double latitude) {
         this.latitude = latitude;
     }
 
-    public @NotNull(message = "Longitude can not be empty") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double getLongitude() {
+    public @NotNull(message = "Longitude can not be empty or null") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double getLongitude() {
         return longitude;
     }
 
-    public void setLongitude(@NotNull(message = "Longitude can not be empty") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double longitude) {
+    public void setLongitude(@NotNull(message = "Longitude can not be empty or null") @Min(value = -180L, message = "Latitude has to be between -180 & +180") @Max(value = 180L, message = "Latitude has to be between -180 & +180") Double longitude) {
         this.longitude = longitude;
     }
 }

--- a/src/main/java/com/AirBnb/TimberAndStone/models/Amenity.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/models/Amenity.java
@@ -6,11 +6,11 @@ import jakarta.validation.constraints.Size;
 
 public class Amenity {
 
-    @NotNull(message = "AmenityTitle cant be null")
+    @NotNull(message = "AmenityTitle can not be null")
     private AmenityTitle amenityTitle;
 
-    @NotNull(message = "Description can not be null")
-    @NotEmpty(message = "Description can not be empty")
+
+    @NotEmpty(message = "Description can not be empty or null")
     @Size(min = 1, max = 500, message = "Description has to be between 1-500 characters")
     private String description;
 
@@ -23,19 +23,19 @@ public class Amenity {
 //--------------------------------------------- Getter & Setters -------------------------------------------------------
 
 
-    public @NotNull(message = "AmenityTitle cant be null") AmenityTitle getAmenityTitle() {
+    public @NotNull(message = "AmenityTitle can not be null") AmenityTitle getAmenityTitle() {
         return amenityTitle;
     }
 
-    public void setAmenityTitle(@NotNull(message = "AmenityTitle cant be null") AmenityTitle amenityTitle) {
+    public void setAmenityTitle(@NotNull(message = "AmenityTitle can not be null") AmenityTitle amenityTitle) {
         this.amenityTitle = amenityTitle;
     }
 
-    public @NotNull(message = "Description can not be null") @NotEmpty(message = "Description can not be empty") @Size(min = 1, max = 500, message = "Description has to be between 1-500 characters") String getDescription() {
+    public @NotEmpty(message = "Description can not be empty or null") @Size(min = 1, max = 500, message = "Description has to be between 1-500 characters") String getDescription() {
         return description;
     }
 
-    public void setDescription(@NotNull(message = "Description can not be null") @NotEmpty(message = "Description can not be empty") @Size(min = 1, max = 500, message = "Description has to be between 1-500 characters") String description) {
+    public void setDescription(@NotEmpty(message = "Description can not be empty or null") @Size(min = 1, max = 500, message = "Description has to be between 1-500 characters") String description) {
         this.description = description;
     }
 }

--- a/src/main/java/com/AirBnb/TimberAndStone/models/Rental.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/models/Rental.java
@@ -17,7 +17,7 @@ public class Rental {
     private String id;
 
     @NotNull(message = "Title can not be null")
-    @NotEmpty(message = "Title can not be empty")
+    //@NotEmpty(message = "Title can not be empty")
     @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters")
     private String title;
 
@@ -82,9 +82,12 @@ public class Rental {
         return id;
     }
 
-    public @NotNull(message = "Title can not be null") @NotEmpty(message = "Title can not be empty") @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters") String getTitle() {
+
+
+    public @NotNull(message = "Title can not be null") @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters") String getTitle() {
         return title;
     }
+
 
     public void setTitle(@NotNull(message = "Title can not be null") @NotEmpty(message = "Title can not be empty") @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters") String title) {
         this.title = title;

--- a/src/main/java/com/AirBnb/TimberAndStone/models/Rental.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/models/Rental.java
@@ -16,12 +16,12 @@ public class Rental {
     @Id
     private String id;
 
-    @NotNull(message = "Title can not be null")
-    //@NotEmpty(message = "Title can not be empty")
+    //@NotNull(message = "Title can not be null")
+    @NotEmpty(message = "Title can not be empty")
     @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters")
     private String title;
 
-    @NotNull(message = "Photos can not be null")
+    //@NotNull(message = "Photos can not be null")
     @Size(max = 10, message = "You can add max 10 photos")
     private List<String> photos;
 
@@ -89,7 +89,7 @@ public class Rental {
     }
 
 
-    public void setTitle(@NotNull(message = "Title can not be null") @NotEmpty(message = "Title can not be empty") @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters") String title) {
+    public void setTitle(@NotEmpty(message = "Title can not be empty") @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters") String title) {
         this.title = title;
     }
 

--- a/src/main/java/com/AirBnb/TimberAndStone/models/Rental.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/models/Rental.java
@@ -16,7 +16,7 @@ public class Rental {
     @Id
     private String id;
 
-    //@NotNull(message = "Title can not be null")
+    @NotNull(message = "Title can not be null")
     @NotEmpty(message = "Title can not be empty")
     @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters")
     private String title;

--- a/src/main/java/com/AirBnb/TimberAndStone/requests/rental/RentalRequest.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/requests/rental/RentalRequest.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class RentalRequest {
 
     @NotNull(message = "Title can not be null")
-    @NotEmpty(message = "Title can not be empty")
+    //@NotEmpty(message = "Title can not be empty")
     @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters")
     private String title;
 
@@ -73,7 +73,7 @@ public class RentalRequest {
     //--------------------------------------------- Getters ------------------------------------------------------------
 
 
-    public @NotNull(message = "Title can not be null") @NotEmpty(message = "Title can not be empty") @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters") String getTitle() {
+    public @NotNull(message = "Title can not be null") @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters") String getTitle() {
         return title;
     }
 

--- a/src/main/java/com/AirBnb/TimberAndStone/requests/rental/RentalRequest.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/requests/rental/RentalRequest.java
@@ -5,47 +5,46 @@ import com.AirBnb.TimberAndStone.models.Amenity;
 import com.AirBnb.TimberAndStone.models.Category;
 import com.AirBnb.TimberAndStone.models.Period;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
 
 import java.util.List;
 
 public class RentalRequest {
 
-    @NotNull(message = "Title can not be null")
+    //@NotNull(message = "Title can not be null")
     //@NotEmpty(message = "Title can not be empty")
-    @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters")
+    //@Size(min = 1, max = 50, message = "Title has to be between 1-50 characters")
     private String title;
 
-    @NotNull(message = "Photos can not be null")
-    @Size(max = 10, message = "You can add max 10 photos")
+    //@NotNull(message = "Photos can not be null")
+    //@Size(max = 10, message = "You can add max 10 photos")
     private List<String> photos;
 
-    @NotNull(message = "Price per night can not be null")
-    @Min(value = 1, message = "PricePerNight have to be minimum 1")
-    @Max(value = 1000000, message = "PricePerNight have to be max 1 000 000")
+    //@NotNull(message = "Price per night can not be null")
+    //@Min(value = 1, message = "PricePerNight have to be minimum 1")
+    //@Max(value = 1000000, message = "PricePerNight have to be max 1 000 000")
     private Double pricePerNight;
 
-    @NotNull(message = "Address can not be null")
+    //@NotNull(message = "Address can not be null")
     @Valid
     private Address address;
 
-    @NotNull(message = "Category can not be null")
+    //@NotNull(message = "Category can not be null")
     private Category category;
 
-    @NotNull(message = "Amenities can not be null")
+    //@NotNull(message = "Amenities can not be null")
     @Valid
     private List<Amenity> amenities;
 
-    @NotNull(message = "Capacity can not be null")
+    //@NotNull(message = "Capacity can not be null")
     private Integer capacity;
 
-    @NotNull(message = "Periods can not be null")
+    //@NotNull(message = "Periods can not be null")
     @Valid
     private List<Period> availablePeriods;
 
-    @NotNull(message = "Description can not be null")
-    @NotEmpty(message = "Description can not be empty")
-    @Size(min = 1, max = 500, message = "Description has to be between 1-500 characters")
+    //@NotNull(message = "Description can not be null")
+    //@NotEmpty(message = "Description can not be empty")
+    //@Size(min = 1, max = 500, message = "Description has to be between 1-500 characters")
     private String description;
 
     private String policy;
@@ -73,43 +72,83 @@ public class RentalRequest {
     //--------------------------------------------- Getters ------------------------------------------------------------
 
 
-    public @NotNull(message = "Title can not be null") @Size(min = 1, max = 50, message = "Title has to be between 1-50 characters") String getTitle() {
+    public String getTitle() {
         return title;
     }
 
-    public @NotNull(message = "Photos can not be null") @Size(max = 10, message = "You can add max 10 photos") List<String> getPhotos() {
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public List<String> getPhotos() {
         return photos;
     }
 
-    public @NotNull(message = "Price per night can not be null") @Min(value = 1, message = "PricePerNight have to be minimum 1") @Max(value = 1000000, message = "PricePerNight have to be max 1 000 000") Double getPricePerNight() {
+    public void setPhotos(List<String> photos) {
+        this.photos = photos;
+    }
+
+    public Double getPricePerNight() {
         return pricePerNight;
     }
 
-    public @NotNull(message = "Address can not be null") @Valid Address getAddress() {
+    public void setPricePerNight(Double pricePerNight) {
+        this.pricePerNight = pricePerNight;
+    }
+
+    public @Valid Address getAddress() {
         return address;
     }
 
-    public @NotNull(message = "Category can not be null") Category getCategory() {
+    public void setAddress(@Valid Address address) {
+        this.address = address;
+    }
+
+    public Category getCategory() {
         return category;
     }
 
-    public @NotNull(message = "Amenities can not be null") @Valid List<Amenity> getAmenities() {
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    public @Valid List<Amenity> getAmenities() {
         return amenities;
     }
 
-    public @NotNull(message = "Capacity can not be null") Integer getCapacity() {
+    public void setAmenities(@Valid List<Amenity> amenities) {
+        this.amenities = amenities;
+    }
+
+    public Integer getCapacity() {
         return capacity;
     }
 
-    public @NotNull(message = "Periods can not be null") @Valid List<Period> getAvailablePeriods() {
+    public void setCapacity(Integer capacity) {
+        this.capacity = capacity;
+    }
+
+    public @Valid List<Period> getAvailablePeriods() {
         return availablePeriods;
     }
 
-    public @NotNull(message = "Description can not be null") @NotEmpty(message = "Description can not be empty") @Size(min = 1, max = 500, message = "Description has to be between 1-500 characters") String getDescription() {
+    public void setAvailablePeriods(@Valid List<Period> availablePeriods) {
+        this.availablePeriods = availablePeriods;
+    }
+
+    public String getDescription() {
         return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public String getPolicy() {
         return policy;
+    }
+
+    public void setPolicy(String policy) {
+        this.policy = policy;
     }
 }

--- a/src/main/java/com/AirBnb/TimberAndStone/requests/rental/RentalRequest.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/requests/rental/RentalRequest.java
@@ -10,41 +10,18 @@ import java.util.List;
 
 public class RentalRequest {
 
-    //@NotNull(message = "Title can not be null")
-    //@NotEmpty(message = "Title can not be empty")
-    //@Size(min = 1, max = 50, message = "Title has to be between 1-50 characters")
+
     private String title;
-
-    //@NotNull(message = "Photos can not be null")
-    //@Size(max = 10, message = "You can add max 10 photos")
     private List<String> photos;
-
-    //@NotNull(message = "Price per night can not be null")
-    //@Min(value = 1, message = "PricePerNight have to be minimum 1")
-    //@Max(value = 1000000, message = "PricePerNight have to be max 1 000 000")
     private Double pricePerNight;
-
-    //@NotNull(message = "Address can not be null")
     @Valid
     private Address address;
-
-    //@NotNull(message = "Category can not be null")
     private Category category;
-
-    //@NotNull(message = "Amenities can not be null")
     @Valid
     private List<Amenity> amenities;
-
-    //@NotNull(message = "Capacity can not be null")
     private Integer capacity;
-
-    //@NotNull(message = "Periods can not be null")
     @Valid
     private List<Period> availablePeriods;
-
-    //@NotNull(message = "Description can not be null")
-    //@NotEmpty(message = "Description can not be empty")
-    //@Size(min = 1, max = 500, message = "Description has to be between 1-500 characters")
     private String description;
 
     private String policy;

--- a/src/main/java/com/AirBnb/TimberAndStone/services/RentalReviewService.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/services/RentalReviewService.java
@@ -147,13 +147,6 @@ updateRentalRating
 
 
     public List<RentalReviewsResponse> getRentalReviewByRentalId(String id) {
-        if ("null".equals(id)) {
-            throw new IllegalArgumentException("Rental id cannot be 'null'");
-        }
-
-        if (id.isEmpty()) {
-            throw new IllegalArgumentException("Rental id cannot be empty");
-        }
 
         if (!rentalRepository.existsById(id)) {
             throw new ResourceNotFoundException("Rental not found");

--- a/src/main/java/com/AirBnb/TimberAndStone/services/RentalReviewService.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/services/RentalReviewService.java
@@ -147,7 +147,15 @@ updateRentalRating
 
 
     public List<RentalReviewsResponse> getRentalReviewByRentalId(String id) {
-        if(!rentalRepository.existsById(id)) {
+        if ("null".equals(id)) {
+            throw new IllegalArgumentException("Rental id cannot be 'null'");
+        }
+
+        if (id.isEmpty()) {
+            throw new IllegalArgumentException("Rental id cannot be empty");
+        }
+
+        if (!rentalRepository.existsById(id)) {
             throw new ResourceNotFoundException("Rental not found");
         }
 

--- a/src/main/java/com/AirBnb/TimberAndStone/services/RentalService.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/services/RentalService.java
@@ -57,9 +57,41 @@ public class RentalService {
         rental.setRating(rating);
         rental.setHost(user);
 
+        // Validate title can not be empty or null
         String title = rentalRequest.getTitle();
         if (title == null || title.trim().isEmpty()) {
-            throw new IllegalArgumentException("Title cannot be null or empty");
+            throw new IllegalArgumentException("Title can not be null or empty");
+        }
+        // Validate photos is not more than 10
+        List<String> photos = rentalRequest.getPhotos();
+        if (photos != null && photos.size() > 10) {
+            throw new IllegalArgumentException("Can not have more than 10 photos");
+        }
+
+        // Validate pricePerNight is between 1-1000000
+        Double pricePerNight = rentalRequest.getPricePerNight();
+        if (pricePerNight == null) {
+            throw new IllegalArgumentException("Price per night can not be null");
+        }
+        if (pricePerNight < 1 || pricePerNight > 1000000) {
+            throw new IllegalArgumentException("Price per night must be between 1 and 1000000");
+        }
+        // Validate category is not null
+        Category category = rentalRequest.getCategory();
+        if (category == null) {
+            throw new IllegalArgumentException("Category can not be null");
+        }
+
+        // Validate capacity is at least 1
+        Integer capacity = rentalRequest.getCapacity();
+        if (capacity == null || capacity < 1) {
+            throw new IllegalArgumentException("Capacity must be at least 1");
+        }
+
+        // Validate description is not empty or null
+        String description = rentalRequest.getDescription();
+        if (description == null || description.trim().isEmpty()) {
+            throw new IllegalArgumentException("Description can not be null or empty");
         }
 
         // DTON

--- a/src/main/java/com/AirBnb/TimberAndStone/services/RentalService.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/services/RentalService.java
@@ -57,6 +57,11 @@ public class RentalService {
         rental.setRating(rating);
         rental.setHost(user);
 
+        String title = rentalRequest.getTitle();
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("Title cannot be null or empty");
+        }
+
         // DTON
         rental.setAddress(rentalRequest.getAddress());
         rental.setAvailablePeriods(rentalRequest.getAvailablePeriods());


### PR DESCRIPTION
PULL REQUEST STANDARD EX:

# Pull Request Template

## Notes & Questions For The Reviewer
We were getting double validation messages for creating a rental (for title, country, city, postalcode, streetname, streetnumber, latitude and longitude, amenity description) and needed to change so only one error message showed. 
Please test creating a rental where leaving the listed values empty or null to check for error message.

## What has been changed?
Removed double validation from RentalRequest, changed @NotNull for some string values to @NotEmpty and error message to "can not be null or empty". Added create rental validation to RentalService instead.

POST   /api/rental          - Create rental and check error messages for null or empty fields

## Why did I make these changes?
To stop double validation messages

## How can others test my code?
check out branch
start server
test every endpoint in postman
Test putting fields as empty or null

Checklist before sending in you PR
Check each box by adding an X to [ ] - [x]
[x] - I have tested my code and it works the way i want it to
[x] - My code follows our code standards (tex validation, names, etc)
[x] - I have commented komplicated parts of code (if needed)
[x] - I have uppdated dokumentation (if needed)

Remember that:
Be humble and open for feedback
Answer the comments quickly
Its okay to make mistakes
