### PR TITLE
134 handle null rental input for getting rentalreviews by rental id and by host

### DIFF
--- a/src/main/java/com/AirBnb/TimberAndStone/services/RentalReviewService.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/services/RentalReviewService.java
@@ -144,7 +144,9 @@ updateRentalRating
 
 
     public List<RentalReviewsResponse> getRentalReviewByRentalId(String id) {
-
+        if (id == null || id.isEmpty() || "null".equals(id)) {
+            throw new IllegalArgumentException("Rental id cannot be 'null' or empty");
+        }
         if (!rentalRepository.existsById(id)) {
             throw new ResourceNotFoundException("Rental not found");
         }

--- a/src/main/java/com/AirBnb/TimberAndStone/services/RentalReviewService.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/services/RentalReviewService.java
@@ -164,7 +164,6 @@ updateRentalRating
         }
         List<Rental> rentals = rentalRepository.findByHostId(id);
 
-        System.out.println("Found Rentals: " + rentals);
         if (rentals.isEmpty()) {
             throw new ResourceNotFoundException("No rentals found for this host");
         }
@@ -174,7 +173,6 @@ updateRentalRating
             List<RentalReview> reviewsForRental = rentalReviewRepository.findByToRentalId(rental.getId());
             rentalReviews.addAll(reviewsForRental);
         }
-        System.out.println("Found Reviews: " + rentalReviews);
         return rentalReviews.stream()
                 .map(this::convertToRentalReviewsResponse)
                 .collect(Collectors.toList());

--- a/src/main/java/com/AirBnb/TimberAndStone/services/RentalReviewService.java
+++ b/src/main/java/com/AirBnb/TimberAndStone/services/RentalReviewService.java
@@ -145,7 +145,7 @@ updateRentalRating
 
     public List<RentalReviewsResponse> getRentalReviewByRentalId(String id) {
         if (id == null || id.isEmpty() || "null".equals(id)) {
-            throw new IllegalArgumentException("Rental id cannot be 'null' or empty");
+            throw new IllegalArgumentException("Rental id can not be 'null' or empty");
         }
         if (!rentalRepository.existsById(id)) {
             throw new ResourceNotFoundException("Rental not found");
@@ -159,6 +159,9 @@ updateRentalRating
     }
 
     public List<RentalReviewsResponse> getRentalReviewByHostId(String id) {
+        if (id == null || id.isEmpty() || "null".equals(id)) {
+            throw new IllegalArgumentException("Host id can not be 'null' or empty");
+        }
         if (!userRepository.existsById(id)) {
             throw new ResourceNotFoundException("Host not found");
         }


### PR DESCRIPTION
## Notes & Questions For The Reviewer

Link to documentation: https://documenter.getpostman.com/view/40894421/2sAYXFjdjp#82972f6a-f272-4125-a049-bad60469c7c1
For easy testing you can use this id for finding by rental id: 67af5b91f0e13237b90c99f8
And this id for finding by host id: 67aca1e0fe35b52300cbbbac

First, find rental review by rental id. Then check for validation when entering "null" as id to get null validation message. For no id "rental not found"-message appears.
Then do the same for finding rental review by host id.

## What has been changed?
Added null validation for finding rental review by rental id and host id

GET    /api/rentalreviews/rental/{id}     - Get rental review by rental id
GET    /api/rentalreviews/rental/host/{id}     - Get rental review by host id


## Why did I make these changes?
We needed null validation for these two endpoints.

## How can others test my code?
check out branch
start server
test every endpoint in postman
Test negativ scenarios, for example making error or trying to find resources that dont exist.

Checklist before sending in you PR
Check each box by adding an X to [ ] - [x]
[x] - I have tested my code and it works the way i want it to
[x] - My code follows our code standards (tex validation, names, etc)
[x] - I have commented komplicated parts of code (if needed)
[x] - I have uppdated dokumentation (if needed)

Remember that:
Be humble and open for feedback
Answer the comments quickly
Its okay to make mistakes
